### PR TITLE
Fix rate limit validation error for unlimited accounts

### DIFF
--- a/src/openrouter_client/client.py
+++ b/src/openrouter_client/client.py
@@ -261,6 +261,11 @@ class OpenRouterClient:
                 self.logger.warning("Missing requests or interval in rate_limit")
                 return
             
+            # Handle special case where requests = -1 (unlimited/no limit)
+            if int(requests) <= 0:
+                self.logger.debug(f"API returned unlimited rate limit (requests={requests}), skipping rate limit configuration")
+                return
+            
             # Convert interval to seconds
             try:
                 time_period = self._parse_interval_to_seconds(interval)


### PR DESCRIPTION
## Summary

Fixes a Pydantic validation error that occurs when the OpenRouter API returns `requests: -1` to indicate unlimited rate limits.

## Problem

The client encounters validation errors when OpenRouter returns `-1` for unlimited accounts:

```
ERROR:openrouter_client.http: Failed to set rate limit: 1 validation error for RateLimit
max_requests
  Input should be greater than or equal to 1 [type=greater_than_equal, input_value=-1, input_type=int]
```

## Solution

Added a simple check in `_initialize_rate_limit()` to skip rate limit configuration when `requests <= 0`:

```python
# Handle special case where requests = -1 (unlimited/no limit)
if int(requests) <= 0:
    self.logger.debug(f"API returned unlimited rate limit (requests={requests}), skipping rate limit configuration")
    return
```

## Testing

Confirmed the fix resolves the validation errors for unlimited accounts while maintaining functionality for standard rate-limited accounts.

**Contributed by @jmazzahacks**